### PR TITLE
Add database bindings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.swp
 *.tgz
+node_modules/
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@
 const Action = require('./lib/action');
 const Adapter = require('./lib/adapter');
 const Constants = require('./lib/constants');
+const Database = require('./lib/database');
 const Deferred = require('./lib/deferred');
 const Device = require('./lib/device');
 const Event = require('./lib/event');
@@ -19,6 +20,7 @@ module.exports = {
   Action,
   Adapter,
   Constants,
+  Database,
   Deferred,
   Device,
   Event,

--- a/lib/database.js
+++ b/lib/database.js
@@ -1,0 +1,151 @@
+/**
+ * Wrapper around the gateway's database.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+const DB_PATHS = [
+  path.join(os.homedir(), 'mozilla-iot', 'gateway', 'db.sqlite3'),
+  path.join(os.homedir(), '.mozilla-iot', 'config', 'db.sqlite3'),
+  path.join('.', 'db.sqlite3'),               // if cwd is the gateway dir
+  path.join('..', '..', '..', 'db.sqlite3'),  // if cwd is the add-on dir
+];
+
+if (process.env.hasOwnProperty('MOZIOT_HOME')) {
+  DB_PATHS.push(path.join(process.env.MOZIOT_HOME, 'config', 'db.sqlite3'));
+}
+
+if (process.env.hasOwnProperty('MOZIOT_DATABASE')) {
+  DB_PATHS.push(process.env.MOZIOT_DATABASE);
+}
+
+/**
+ * An Action represents an individual action on a device.
+ */
+class Database {
+  /**
+   * Initialize the object.
+   *
+   * @param {String} packageName The adapter's package name
+   * @param {String?} path Optional database path
+   */
+  constructor(packageName, path = null) {
+    this.packageName = packageName;
+    this.path = path;
+    this.conn = null;
+
+    if (!this.path) {
+      for (const p of DB_PATHS) {
+        if (fs.existsSync(p)) {
+          this.path = p;
+          break;
+        }
+      }
+    }
+  }
+
+  /**
+   * Open the database.
+   */
+  open() {
+    if (!this.path || this.conn) {
+      return;
+    }
+
+    this.conn = new sqlite3.Database(this.path);
+    this.conn.configure('busyTimeout', 10000);
+  }
+
+  /**
+   * Close the database.
+   */
+  close() {
+    if (this.conn) {
+      this.conn.close();
+      this.conn = null;
+    }
+  }
+
+  /**
+   * Load the package's config from the database.
+   *
+   * @returns Promise which resolves to the config object.
+   */
+  loadConfig() {
+    if (!this.conn) {
+      return Promise.reject('Database not open');
+    }
+
+    const key = `addons.${this.packageName}`;
+
+    return new Promise((resolve, reject) => {
+      this.conn.get(
+        'SELECT value FROM settings WHERE key = ?',
+        [key],
+        (error, row) => {
+          if (error) {
+            reject(error);
+          } else {
+            const data = JSON.parse(row.value);
+            if (!data.hasOwnProperty('moziot') ||
+                !data.moziot.hasOwnProperty('config')) {
+              resolve({});
+            } else {
+              resolve(data.moziot.config);
+            }
+          }
+        });
+    });
+  }
+
+  /**
+   * Save the package's config to the database.
+   */
+  saveConfig(config) {
+    if (!this.conn) {
+      return;
+    }
+
+    const key = `addons.${this.packageName}`;
+
+    return new Promise((resolve, reject) => {
+      this.conn.get(
+        'SELECT value FROM settings WHERE key = ?',
+        key,
+        (error, row) => {
+          if (error) {
+            reject(error);
+          } else {
+            const data = JSON.parse(row.value);
+            if (!data.hasOwnProperty('moziot')) {
+              data.moziot = {};
+            }
+
+            data.moziot.config = config;
+
+            this.conn.run(
+              'INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)',
+              [key, JSON.stringify(data)],
+              (error) => {
+                if (error) {
+                  reject(error);
+                } else {
+                  resolve();
+                }
+              });
+          }
+        });
+    });
+  }
+}
+
+module.exports = Database;

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "url": "https://github.com/mozilla-iot/gateway-addon-node/issues"
   },
   "dependencies": {
+    "sqlite3": "^4.0.0"
   },
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "files": [
     "LICENSE",
     "index.js",


### PR DESCRIPTION
These are essentially copied from gateway-addon-python.
We'll need these to update configs in accordance with new
schemas.