### PR TITLE
Add database.js to deployed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lib/action.js",
     "lib/adapter.js",
     "lib/constants.js",
+    "lib/database.js",
     "lib/deferred.js",
     "lib/device.js",
     "lib/event.js",


### PR DESCRIPTION
It will prevent a failure like:

  Error: Cannot find module './lib/database'