### PR TITLE
device: Generate default id if unset as param

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -17,7 +17,10 @@ const ajv = new Ajv();
 
 class Device {
   constructor(adapter, id) {
-    if (typeof id !== 'string') {
+    Device.count = (Device.count || 0) + 1;
+    if (typeof id === 'undefined' || id === null) {
+      id = `device-${Device.count}`;
+    } else if (typeof id !== 'string') {
       id = id.toString();
     }
 


### PR DESCRIPTION
To avoid overlaping of ids,
use default value that result of incrementing an instance counter.

To avoid collision with existing numbers, 'device' prefix is added.

IHMO, It will be safer to rely on default id when possible.

Change-Id: Ifd22aee2aac85229339b769e31a6c7f5f341b7b7
Signed-off-by: Philippe Coval <p.coval@samsung.com>