### PR TITLE
Add function to check if the adjusted property value has changed

### DIFF
--- a/lib/property.js
+++ b/lib/property.js
@@ -104,13 +104,28 @@ class Property {
    * is consistent with the type.
    */
   setCachedValue(value) {
+    this.value = fixType(value);
+    return this.value;
+  }
+
+  /**
+   * Check the new value against the fixed value to ensure that the
+   * type adjustment does not trigger a change.
+   */
+  valueHasChanged(newValue) {
+    return this.value !== fixType(newValue);
+  }
+
+  /**
+   * Makes adjustments to ensure that the value is consistent with the type.
+   */
+  fixType(value) {
     if (this.type === 'boolean') {
       // Make sure that the value is actually a boolean.
-      this.value = !!value;
-    } else {
-      this.value = value;
+      return !!value;
     }
-    return this.value;
+
+    return value;
   }
 
   /**


### PR DESCRIPTION
If an adapter implementation sets the value via `setCachedValue` the value is adjusted before setting `this.value`. The adapter implementation has no chance to check if the new value really has changed or is just different from the adjusted value.

Example:
```
var value = null;

property.type = 'boolean';
property.setCachedValue(value);

var hasChanged = property.value === value;

hasChanged === true;
```

Therefore i propose to move the type adjustment to a separate function and to provide a function which allows to check if the value would still change after the adjustment.

```
var hasChanged = property.valueHasChanged(value);

hasChanged === false;
```